### PR TITLE
Increase flexibility for liveReload injection

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,17 +49,18 @@ function readFileContent(file) {
  * @returns {*} updated file content as string
  */
 function updateFileContent(fileContents, connectURL) {
-  var updatedFileContent,
-    match = fileContents.match(/App.onLaunch = function \((.*)\) {/),
-    options = match ? match[1] : false;
-  if (options) {
-    updatedFileContent = fileContents.replace(/App.onLaunch = function \((.*)\) {/, `App.onLaunch = function (${options}) {
-  liveReload.connect('${connectURL}', App, ${options});`);
-  } else {
-    updatedFileContent = fileContents.replace(/App.onLaunch = function \((.*)\) {/, `App.onLaunch = function () {
-  liveReload.connect('${connectURL}', App);`);
+  var regex = /(App.onLaunch[^\(]*\(\s*([^\)]*)\).*{)/;
+  var match = fileContents.match(regex);
+  var appOptions = match[2];
+  var liveReloadOptions, updatedFileContent;
+
+  if(appOptions) {
+    liveReloadOptions = `liveReload.connect('${connectURL}', App, ${appOptions});`;
+  }else {
+    liveReloadOptions = `liveReload.connect('${connectURL}', App);`;
   }
-  return updatedFileContent;
+
+  return fileContents.replace(regex, `$1\n  ${liveReloadOptions}`);
 }
 
 module.exports = {

--- a/test/applicationAsync.js
+++ b/test/applicationAsync.js
@@ -1,0 +1,3 @@
+App.onLaunch = async () => {
+  console.log('Loaded');
+}

--- a/test/applicationAsyncWithOptions.js
+++ b/test/applicationAsyncWithOptions.js
@@ -1,0 +1,3 @@
+App.onLaunch = async (options) => {
+  console.log('Loaded');
+}

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -29,4 +29,28 @@ App.onLaunch = function (options) {
 
 `);
   });
+
+  it('should add live reload to application.js with variable format', function () {
+    var result = livereload.prepareApplicationJS(__dirname + '/applicationAsync.js', '9001');
+    expect(result).toEqual(`var liveReload = require('${libPath}livereload');
+
+App.onLaunch = async () => {
+  liveReload.connect('http://localhost:9001', App);
+  console.log('Loaded');
+}
+
+`);
+  });
+
+  it('should add live reload to application.js with variable format and options', function () {
+    var result = livereload.prepareApplicationJS(__dirname + '/applicationAsyncWithOptions.js', '9001');
+    expect(result).toEqual(`var liveReload = require('${libPath}livereload');
+
+App.onLaunch = async (options) => {
+  liveReload.connect('http://localhost:9001', App, options);
+  console.log('Loaded');
+}
+
+`);
+  });
 });


### PR DESCRIPTION
Currently the library injects the liveReload functionality under specific circumstances i.e with the onLaunch method written as either:

`App.onLaunch = function () {}`

or

`App.onLaunch = function (options) {}
`

This PR account for other cases such as including async functionality or arrow functions etc.

